### PR TITLE
Add a note about installing during beta release

### DIFF
--- a/en/install.md
+++ b/en/install.md
@@ -40,8 +40,7 @@ snapd:
 
         sudo snap install snapstore --beta
 
-Installing the stable release of the Snap Enterprise Proxy
-is as simple as:
+Installing the stable release of the Snap Enterprise Proxy is as simple as:
 
     sudo snap install snapstore
 

--- a/en/install.md
+++ b/en/install.md
@@ -35,7 +35,13 @@ snapd:
 
     sudo systemctl restart snapd
 
-Then installing the snap is as simple as:
+!!! NOTE:
+    While the Snap Enterprise Proxy is in beta the snap can be installed using:
+
+        sudo snap install snapstore --beta
+
+Installing the stable release of the Snap Enterprise Proxy
+is as simple as:
 
     sudo snap install snapstore
 


### PR DESCRIPTION
During the beta release, the standard installation instructions will not work.

Include a note covering using the beta channel installation