### PR TITLE
Documentation history update/transplant

### DIFF
--- a/docs/en/https.md
+++ b/docs/en/https.md
@@ -1,0 +1,70 @@
+---
+title: HTTPS
+table_of_contents: true
+---
+
+# HTTPS
+
+TLS termination is not enabled by default. This means that the traffic between
+your snap devices and the Snap Store Proxy will not be encrypted.
+
+This document explains how to enable TLS termination in the Snap Store Proxy.
+
+!!! NOTE:
+    Follow the instructions below **after** your Snap Store Proxy is
+    [installed](install.md), but **before** it is [registered](register.md) and
+    before any snap devices are [configured](devices.md) to use this Snap Store
+    Proxy.
+
+## Certificate and Key
+
+Obtain an x509 key and certificate pair for your Snap Store Proxy domain. You can
+determine the domain by running:
+
+    snap-proxy config proxy.domain
+
+This name will be the subject or one of the alternative names on the certificate.
+
+How to obtain the certificate/key pair is out of scope of this document.
+
+## Importing the Key/Certificate pair
+
+Running the below command will import the key/certificate pair and re-configure
+your Snap Store Proxy:
+
+    cat my.cert my.key | sudo snap-proxy import-certificate
+
+After this is done, TLS termination will be enabled, and any HTTP traffic to
+your Snap Store Proxy will be redirected to HTTPS.
+
+## Self signed certificates
+
+The TLS certificate above may be self signed or issued by a certificate
+authority that is not included in the system certificate store on your snap
+devices. If this is true, then you need to make sure that the certificates in
+question are added to the system certificate store on those devices. On Ubuntu
+devices this might be achieved by placing the certificate in question in a
+specific directory:
+
+    sudo cp selfsigned.crt /usr/local/share/ca-certificates/
+
+then running:
+
+    sudo update-ca-certificates
+
+and finally, `snapd` has to be restarted.
+
+    sudo systemctl restart snapd
+
+After that, snapd will be able to successfully verify the certificate.
+
+## Next step
+
+Once you've confirmed that your Snap Store Proxy is running and accepting HTTPS
+connections, you can [register](register.md) your Snap Store Proxy.
+
+At any time, you can use:
+
+    snap-proxy status
+
+to check the status of your Snap Store Proxy.

--- a/en/api-authentication.md
+++ b/en/api-authentication.md
@@ -43,7 +43,7 @@ Response:
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: applicaton/json
+Content-Type: application/json
 ...
 
 {

--- a/en/devices.md
+++ b/en/devices.md
@@ -13,7 +13,7 @@ You will need at least snapd 2.30 on your device and access to a
 To configure snapd on a device to talk to the proxy, you need to `snap
 ack` the signed assertion that allows snapd to trust the proxy, e.g.:
 
-    curl -s http://<domain>/v2/auth/store/assertions | sudo snap ack /dev/stdin
+    curl -sL http://<domain>/v2/auth/store/assertions | sudo snap ack /dev/stdin
 
 Once snapd knows about the store assertion, you then have to configure it to use the proxy:
 

--- a/en/install.md
+++ b/en/install.md
@@ -57,27 +57,31 @@ database already prepared, or the ability to install PostgreSQL locally.
 
 ### Prepared database
 
-Choose this approach if you are experience with PostgreSQL and want to setup a
+Choose this approach if you are experienced with PostgreSQL and want to setup a
 production ready installation.
 
 You will need to create a database:
+
     CREATE DATABASE dbname;
 
 And a new user:
+
     CREATE ROLE user LOGIN CREATEROLE PASSWORD 'password';
 
 The user needs to be able to create objects in the database:
+
     GRANT CREATE ON DATABASE dbname TO user;
 
 A prepared database must have the 
 [btree_gist](https://www.postgresql.org/docs/current/static/btree-gist.html) 
 extension installed. This extension requires superuser privileges to create.
 You should connect to DBNAME as a superuser and create the extension:
+
     CREATE EXTENSION btree_gist;
 
 Once the database is prepared, set the connection string.
-    sudo snap-store-proxy config \
-        proxy.db.connection="postgresql://USER:PASSWORD@HOST:PGPORT/DBNAME"
+
+    sudo snap-proxy config proxy.db.connection="postgresql://USER:PASSWORD@HOST:PGPORT/DBNAME"
 
 The connection string behaves as per [normal PostgreSQL
 clients](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
@@ -88,16 +92,17 @@ There is a convenience option that will guide you through creating and
 configuring the database.
 
 It assumes you will install PostgreSQL locally on Ubuntu:
+
     sudo apt install postgresql
 
-Once PostgreSQL is install create the snapstore admin user. You need to 
+Once PostgreSQL is installed, create the snapstore admin user. You need to
 choose a good password:
-    sudo su - postgres -c 'createuser --login --createrole --encrypted \
-        --pwprompt snapstore'
+
+    sudo -u postgres createuser --login --createrole --createdb --encrypted --pwprompt snapstore
 
 Now run create-database and follow the instructions it gives:
-    sudo snap-store-proxy create-database \
-        "postgresql://snapstore@localhost:5432/snapstore"
+
+    sudo snap-proxy create-database "postgresql://snapstore@localhost:5432/snapstore"
 
 This will setup and configure the database.
 

--- a/en/install.md
+++ b/en/install.md
@@ -14,11 +14,7 @@ To run the Snap Store Proxy, you will need:
   connections to https://api.snapcraft.io,
   https://public.apps.ubuntu.com, and https://login.ubuntu.com.
 * A domain name for the server.
-* A PostgreSQL instance, and credentials for a user with `CREATEROLE`
-  privileges, and either `CREATEDB` or a pre-created database with `CREATE`
-  privileges on it for that user.  The snap-store-proxy snap will create
-  "snapauth" and "snaprevs" users, so you will need to ensure that any
-  relevant ACLs permit those.
+* A PostgreSQL instance (see the Database section). 
 * An RSA key pair to register the snap-store-proxy identity (these can be
   generated for you with: `snap-proxy generate-keys`).
 
@@ -57,42 +53,57 @@ The proxy will listen on all interfaces on port 443 (with a redirect from 80).
 ## Database
 
 To initially configure the Snap Store Proxy, you will need either a
-database already prepared, or a [connection
-string](https://www.postgresql.org/docs/current/static/libpq-connect.html#id-1.7.3.8.3.6)
-with a user with CREATEDB permissions.
+database already prepared, or the ability to install PostgreSQL locally. 
 
 ### Prepared database
 
-A prepared database must have the [btree_gist](https://www.postgresql.org/docs/current/static/btree-gist.html) extension installed.
-This extension requires superuser privileges to create.
+Choose this approach if you are experience with PostgreSQL and want to setup a
+production ready installation.
 
-If the database is already prepared, set the connection string.
+You will need to create a database:
+    CREATE DATABASE dbname;
 
-    sudo snap-proxy config \
+And a new user:
+    CREATE ROLE user LOGIN CREATEROLE PASSWORD password;
+
+The user needs to be able to create objects in the database:
+    GRANT CREATE ON dbname TO user;
+
+A prepared database must have the 
+[btree_gist](https://www.postgresql.org/docs/current/static/btree-gist.html) 
+extension installed. This extension requires superuser privileges to create.
+You should connect to DBNAME as a superuser and create the extension:
+    CREATE EXTENSION btree_gist;
+
+Once the database is prepared, set the connection string.
+    sudo snap-store-proxy config \
         proxy.db.connection="postgresql://USER:PASSWORD@HOST:PGPORT/DBNAME"
 
-This will require a user with CREATEROLE permission but does not require CREATEDB
-permissions.
-
 The connection string behaves as per [normal PostgreSQL
-clients](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING). i.e.
-`USER` will default to 'root', `HOST` defaults to 'localhost', `PGPORT` defaults to '5432', `DBNAME` defaults to `USER`.
+clients](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
 
 ### Creating a database
 
-There is a convenience option that will create and configure the database
-automatically.
+There is a convenience option that will guide you through creating and 
+configuring the database.
 
-The `create-database` command can create a database with a connection string
-including a user that has the appropriate permissions (CREATEDB).
+It assumes you will install PostgreSQL locally on Ubuntu:
+    sudo apt install postgresql
 
-    sudo snap-proxy create-database \
-        "postgresql://USER:PASSWORD@HOST:PGPORT/DBNAME"
+Once PostgreSQL is install create the snapstore admin user.
+You need to choose a good password for PASSWORD.
+    echo 'CREATE ROLE snapstore LOGIN PASSWORD '\''PASSWORD'\'';' | \
+        sudo su - postgres -c psql
+
+Now run create-database. It's necessary to run it multiple times. 
+Follow the instructions it gives:
+    sudo snap-store-proxy create-database \
+        "postgresql://snapstore:PASSWORD@localhost:5432/snapstore"
+
+This will setup and configure the database.
 
 The connection string behaves as per [normal PostgreSQL clients](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING). i.e.
 `USER` will default to 'root', `HOST` defaults to 'localhost', `PGPORT` defaults to '5432', `DBNAME` defaults to `USER`. The `PASSWORD` here is optional, and if needed will be prompted for by the command (to avoid leaving credentials in your shell's history).
-
-This will create and migrate the database.
 
 ## Network connectivity
 
@@ -116,7 +127,7 @@ ready to be [registered](register.md).
 
 You can run multiple instances of the proxy for HA, provided by simple
 round-robin DNS. All instances need to have the same configuration,
-using your normal configuration managment system. Once a key pair has
+using your normal configuration management system. Once a key pair has
 been registered, it will not need registering on other instances.
 
 !!! NOTE:

--- a/en/install.md
+++ b/en/install.md
@@ -120,9 +120,9 @@ with:
 
 ## Next step
 
-With the domain set, and database configured your proxy should now be
-ready to be [registered](register.md).
-
+If you want traffic between your devices and your Snap Store Proxy to be
+encrypted, continue to [HTTPS](https.md). Otherwise, proceed with
+[registration](register.md).
 
 ## Running multiple proxies
 

--- a/en/install.md
+++ b/en/install.md
@@ -113,8 +113,8 @@ needs to with:
 
     snap-proxy check-connections
 
-If you require an HTTPS proxy, you can configure the proxy to use that
-with:
+If you require traffic between your Snap Store Proxy and the internet to go via
+another HTTP proxy, you can configure your Snap Store Proxy to do so with:
 
     sudo snap-proxy config proxy.https.proxy=myproxy.internal:3128
 

--- a/en/install.md
+++ b/en/install.md
@@ -95,12 +95,13 @@ choose a good password:
     sudo su - postgres -c 'createuser --login --createrole --encrypted \
         --pwprompt snapstore'
 
-Now run create-database. It's necessary to run it multiple times. 
-Follow the instructions it gives:
+Now run create-database and follow the instructions it gives:
     sudo snap-store-proxy create-database \
         "postgresql://snapstore@localhost:5432/snapstore"
 
 This will setup and configure the database.
+
+It may be necessary to run the creatre-database command multiple times.
 
 The connection string behaves as per [normal PostgreSQL clients](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING). i.e.
 `USER` will default to 'root', `HOST` defaults to 'localhost', `PGPORT` defaults to '5432', `DBNAME` defaults to `USER`. The `PASSWORD` here is optional, and if needed will be prompted for by the command (to avoid leaving credentials in your shell's history).

--- a/en/install.md
+++ b/en/install.md
@@ -64,10 +64,10 @@ You will need to create a database:
     CREATE DATABASE dbname;
 
 And a new user:
-    CREATE ROLE user LOGIN CREATEROLE PASSWORD password;
+    CREATE ROLE user LOGIN CREATEROLE PASSWORD 'password';
 
 The user needs to be able to create objects in the database:
-    GRANT CREATE ON dbname TO user;
+    GRANT CREATE ON DATABASE dbname TO user;
 
 A prepared database must have the 
 [btree_gist](https://www.postgresql.org/docs/current/static/btree-gist.html) 

--- a/en/install.md
+++ b/en/install.md
@@ -90,15 +90,15 @@ configuring the database.
 It assumes you will install PostgreSQL locally on Ubuntu:
     sudo apt install postgresql
 
-Once PostgreSQL is install create the snapstore admin user.
-You need to choose a good password for PASSWORD.
-    echo 'CREATE ROLE snapstore LOGIN PASSWORD '\''PASSWORD'\'';' | \
-        sudo su - postgres -c psql
+Once PostgreSQL is install create the snapstore admin user. You need to 
+choose a good password:
+    sudo su - postgres -c 'createuser --login --createrole --encrypted \
+        --pwprompt snapstore'
 
 Now run create-database. It's necessary to run it multiple times. 
 Follow the instructions it gives:
     sudo snap-store-proxy create-database \
-        "postgresql://snapstore:PASSWORD@localhost:5432/snapstore"
+        "postgresql://snapstore@localhost:5432/snapstore"
 
 This will setup and configure the database.
 

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -3,6 +3,8 @@ navigation:
       location: index.md
     - title: Installation
       location: install.md
+    - title: HTTPS
+      location: https.md
     - title: Proxy registration
       location: register.md
     - title: Configuring snap devices

--- a/en/register.md
+++ b/en/register.md
@@ -5,17 +5,17 @@ table_of_contents: true
 
 # Registration
 
-## Generate an SSH key pair
+## Configure private and public keys
 
 You will need to configure an RSA key pair in order to register
 the proxy. This acts as the proxy's identity with the upstream Snap Store.
 
-This can be done automatically:
+They can be generated and configured automatically:
 
     sudo snap-proxy generate-keys
 
 Or you can manually generate a key pair, in OpenSSH format (e.g., via
-ssh-keygen) and set explicitly:
+ssh-keygen) and configure it explicitly:
 
     sudo snap-proxy config \
         proxy.key.public="<public key data>" \

--- a/en/trouble.md
+++ b/en/trouble.md
@@ -36,6 +36,18 @@ The default limit is 2GB, this can be changed with:
 
     sudo snap-proxy config proxy.cache.size=4096  # in mb
 
+## Moving to a new hostname
+
+If you need to move the snap-proxy to a new hostname, you can do:
+
+    sudo snap-store-proxy config proxy.domain=NEWDOMAIN
+    sudo snap-store-proxy reregister
+
+This perform another registration cycle and update the assertion file
+with the new domain name.
+This will then need to be acked on the client devices and will replace
+the existing assertion.
+
 ## Documentation
 
 This documentation is shipped with the snap, and available at:

--- a/en/trouble.md
+++ b/en/trouble.md
@@ -40,8 +40,8 @@ The default limit is 2GB, this can be changed with:
 
 If you need to move the snap-proxy to a new hostname, you can do:
 
-    sudo snap-store-proxy config proxy.domain=NEWDOMAIN
-    sudo snap-store-proxy reregister
+    sudo snap-proxy config proxy.domain=NEWDOMAIN
+    sudo snap-proxy reregister
 
 This perform another registration cycle and update the assertion file
 with the new domain name.


### PR DESCRIPTION
1. Update the docs with changes from the original source.
2. Keep the relevant parts of commits and history.

In preparation for this repository becoming the official source for snap-store-proxy docs.