### PR TITLE
Updates to the airgap section

### DIFF
--- a/en/airgap.md
+++ b/en/airgap.md
@@ -8,9 +8,6 @@ table_of_contents: true
 Snap Store Proxy can operate in an air-gapped (offline) mode, meaning it can be
 deployed in networks that are disconnected from the internet.
 
-!!! NOTE:
-    The air-gapped mode is in a closed internal beta currently.
-
 ## Overview
 
 Client devices connect to the air-gapped Snap Store Proxy. The proxy never
@@ -19,7 +16,21 @@ contacts the general Snap Store nor the internet in general.
 Proxy operators side-load all necessary snaps into their air-gapped Snap Store
 Proxy.
 
-## Registration
+## Installation
+
+If the target host has internet access at the time of installation, then the
+regular [installation](install.md) and [registration](register.md) can be used
+followed by airgap mode activation:
+
+```bash
+sudo snap-proxy enable-airgap-mode
+```
+
+### Offline installation
+
+To deploy an air-gapped Snap Store Proxy to a machine without internet access
+it's possible to register it using a separate machine first and install the
+resulting package on the target machine.
 
 Air-gapped Snap Store Proxy operators first have to register their offline proxy
 on a **machine with internet access**:
@@ -47,28 +58,17 @@ sudo snap-proxy register --offline --channel=edge --arch=amd64
 The result of the above is a tarball `offline-snap-store.tar.gz` that is then
 moved to the target host machine for the air-gapped Snap Store Proxy.
 
-## Database setup
-
 The target machine (the air-gapped Snap Store Proxy host) should have network
 access to a [properly configured PostgreSQL database](install.md#database).
 
-## Installation
-
 You will need the `offline-snap-store.tar.gz` bundle from the registration step
 to continue with installation.
-
-!!! NOTE:
-    The air-gapped mode is in a closed internal beta currently and installation
-    is password protected.
 
 The script below illustrates the installation process on the target air-gapped
 machine. Please note that the following variables need to be set appropriately:
 
 * `POSTGRESQL_CONN_STRING` - the connection string to a
   [properly set up PostgreSQL database](install.md#database)
-
-* `SNAPSTORE_BETA_PASSWORD` - a closed beta password required for the
-  installation of the air-gapped Snap Store Proxy
 
 * `PROXY_ACCESS_PASSWORD` - password required for management of the air-gapped
   Snap Store Proxy over the network
@@ -80,8 +80,6 @@ set -eu
 
 # PostgreSQL connection string to the Snap Store Proxy database.
 POSTGRESQL_CONN_STRING="${POSTGRESQL_CONN_STRING}"
-# Closed beta password required for the airgap installation.
-SNAPSTORE_BETA_PASSWORD="${SNAPSTORE_BETA_PASSWORD}"
 # Management access password for the proxy.
 PROXY_ACCESS_PASSWORD="${PROXY_ACCESS_PASSWORD}"
 
@@ -91,18 +89,21 @@ cd offline-snap-store
 
 sudo snap-store-proxy config proxy.db.connection="$POSTGRESQL_CONN_STRING"
 
-SNAPSTORE_BETA_PASSWORD="$SNAPSTORE_BETA_PASSWORD" sudo -E snap-store-proxy enable-airgap-mode --password $PROXY_ACCESS_PASSWORD
+sudo snap-store-proxy enable-airgap-mode --password $PROXY_ACCESS_PASSWORD
 
 sudo snap-store-proxy status
 ```
 
-## Side-loading snaps
 
-Air-gapped Snap Store Proxy operators can fetch snaps from the official Snap
+## Usage
+
+### Side-loading snaps
+
+Air-gapped Snap Store Proxy operators can fetch snaps from the upstream Snap
 Store and import them into their air-gapped proxy. These will be the only snaps
 (and their revisions) available for installation from the air-gapped proxy.
 
-### Fetching snaps
+#### Fetching snaps
 
 Example of fetching the `jq` snap on a **machine with internet access**:
 
@@ -113,7 +114,7 @@ sudo snap-store-proxy fetch-snaps jq --channel=stable --architecture=amd64
 This produces a `tar.gz` file that has to be moved to the air-gapped proxy and
 imported there.
 
-### Importing (pushing) snaps
+#### Importing (pushing) snaps
 
 Once the snap bundles are on the airgap host, they should be moved to the
 `/var/snap/snap-store-proxy/common/snaps-to-push/` directory, from where they
@@ -129,17 +130,32 @@ The `jq` snap is now available for installation from this air-gapped Snap Store
 Proxy. This means that `snap info jq` and `snap install jq` will succeed on a
 connected client device.
 
-## Client Device Configuration
+### Essential snaps
 
-Client devices only ever connect to the offline proxy. They do this without
-sending any device authentication/authorization information to the proxy. A
-client device that has already obtained a
-[serial assertion](https://docs.ubuntu.com/core/en/reference/assertions/serial),
-will not be able to use the air-gapped proxy, as the air-gapped proxy currently
-is unable to authenticate its client devices offline.
+Devices that connect to a store expect that snaps pre-installed on those devices
+will be available in that store. Otherwise common operations like `snap refresh`
+will fail. Air-gapped store operators should ensure that all necessary snaps are
+imported. Snaps commonly pre-installed on devices may include but are not
+limited to:
+
+- `core`
+- `core18`
+- `snapd`
+
+## Client Device Configuration
 
 [Configuring client devices](devices.md) follows the same process as with an
 online Snap Store Proxy.
+
+!!! NOTE:
+    Airgapped Snap Store Proxy ignores authentication information sent by client
+    devices currently. However if a client device has already obtained a
+    [serial assertion](https://docs.ubuntu.com/core/en/reference/assertions/serial),
+    but hasn't yet obtained a device session credential from the upstream store,
+    it will not be able to use the air-gapped proxy, as the air-gapped proxy
+    currently is unable to authenticate its client devices offline and the
+    device tries to obtain a session from the store it connects to before
+    talking to that store.
 
 ## Limitations
 


### PR DESCRIPTION
- no beta password required
- online installation option mentioned
- essential/common snaps section added
- more detailed note on missing client authentication