### PR TITLE
Introduce the --https option for the register command

### DIFF
--- a/en/airgap-device-auth.md
+++ b/en/airgap-device-auth.md
@@ -1,0 +1,165 @@
+---
+title: Device Authenticated Air-gapped mode
+table_of_contents: true
+---
+
+# Device Authenticated Air-gapped mode
+
+[Brand Store](https://ubuntu.com/core/docs/store-overview) customers can use the
+Snap Store Proxy in air-gapped mode to serve updates to their fleet of devices.
+
+Operators can import their brand store snaps (including any essential and other
+snaps included from the global store in their brand store) to their airgap Snap
+Store Proxy.
+
+Devices with valid serial assertions for models belonging to a specific brand
+can authenticate to such proxy and get access to imported brand store snaps
+which are not accessible to any other devices connecting to that proxy.
+
+Follow the instructions below to setup your air-gapped proxy in a way that
+allows for brand devices to be able access and update their brand store (and
+brand store included) snaps.
+
+!!! NOTE:
+    The client devices have to be equipped with their serial assertions and the
+    air-gapped proxy itself does not support device registration.
+
+!!! NOTE:
+    The client devices should only ever connect to their target air-gapped
+    proxy, to ensure that the device session they obtain is signed with the
+    air-gapped proxy unique secret key (`snap-store-proxy config
+    proxy.device-auth.secret`). This unique key is generated when air-gapped
+    mode is activated for a proxy, and it should be securely backed up.
+
+### Fetching brand store snaps
+
+To fetch non publicly available brand store snaps for a subsequent import to the
+air-gapped proxy, the `fetch-snaps` command with its `--auth` and `--store`
+options can be used. First a login file has to be obtained from an account with
+a *Viewer* role for the brand store in question, using the `snapcraft` tool:
+
+```bash
+snapcraft export-login --acls package_access
+```
+
+Then this file has to be moved to a location accessible by the snap-store-proxy
+snap, like `/var/snap/snap-store-proxy/common/`, and the snap can be fetched:
+
+```bash
+# On a machine with internet access and the proxy being in online mode:
+sudo snap-store-proxy fetch-snaps <snap-name> \
+    --channel=stable --architecture=amd64 \
+    --auth <path-to-snapcraft-login-file> \
+    --store <brand-store-id>
+```
+
+The above needs to be repeated for all snaps (both brand store and global store)
+that are pre-installed on the airgap proxy client devices, as well as any snaps
+and their dependencies those devices are expected to be able to install later.
+
+To fetch publicly available global store snaps, the `--store` and `--auth`
+options can be omitted.
+
+### Fetching brand store metadata
+
+To fetch brand store metadata needed for import to the air-gapped proxy, the
+`fetch-brand-store-metadata` snap-store-proxy command can be used on a machine
+with internet access. But first a login file has to be obtained from an account
+with an *Admin* role for the brand store in question, using the `snapcraft`
+tool:
+
+```bash
+snapcraft export-login --acls store_admin
+```
+
+Then this file has to be moved to a location accessible by the snap-store-proxy
+snap, like `/var/snap/snap-store-proxy/common/`, and the brand store metadata
+can be fetched:
+
+```bash
+sudo snap-store-proxy fetch-brand-store-metadata <brand-store-id> <path-to-snapcraft-login-file>
+```
+
+### Fetching brand account keys
+
+Any [account
+keys](https://ubuntu.com/core/docs/reference/assertions/account-key) used for
+signing brand devices'
+[models](https://ubuntu.com/core/docs/reference/assertions/model) and
+[serials](https://ubuntu.com/core/docs/reference/assertions/serial) have to be
+registered with the Snap Store using `snapcraft register-key` and then fetched
+and imported to the air-gapped proxy those devices will connect to for the proxy
+to be able to authenticate them.
+
+To fetch those assertions, the snap-store-proxy `fetch-account-keys` can be used:
+
+```bash
+snap-store-proxy fetch-account-keys <brand-account-id> <key-id> <key-id> ...
+```
+
+So if `FQaqU5d8LtMU5L16h47S10R26eDqxZL7NNdJGSOryG6yTSWGeSGEpeFSQZOfH5Tr` key is
+used for signing serials,
+`tQUaubkyr7d0EshPal8oncc0Dj2WBsydl2I2B2O6jRa7Quxs_wUg0jUw3cNBK65G` is used for
+signing models, and the brand account id is `my-brand`:
+
+```bash
+snap-store-proxy fetch-account-keys \
+    my-brand \
+    tQUaubkyr7d0EshPal8oncc0Dj2WBsydl2I2B2O6jRa7Quxs_wUg0jUw3cNBK65G \
+    FQaqU5d8LtMU5L16h47S10R26eDqxZL7NNdJGSOryG6yTSWGeSGEpeFSQZOfH5Tr
+```
+
+### Pushing snaps
+
+All the fetched snaps can be pushed to the air-gapped proxy using the regular
+`push-snaps` command:
+
+```bash
+sudo snap-store-proxy push-snap <path-to-fetched-snap.tar.gz>
+```
+
+### Pushing brand store metadata
+
+After all required snaps have been pushed (`snap-store-proxy list-pushed-snaps`
+can be used to see the current status), the brand store metadata must be
+imported to the air-gapped proxy using:
+
+```bash
+sudo snap-store-proxy push-brand-store-metadata <path-to-fetched-store-metadata.json>
+```
+
+### Pushing account keys
+
+And lastly the fetched account keys need to be imported:
+
+```bash
+sudo snap-store-proxy push-account-keys <path-to-fetched-keys-file.assert>
+```
+
+### Status
+
+`snap-store-proxy status` lists the imported stores and account keys and
+`snap-store-proxy list-pushed-snaps` lists all imported snaps.
+
+Running `snap info <snap-name>` from a device connected to the air-gapped proxy
+can be used to view more details about the snap, like it's current channel map.
+
+
+### Proxy config backup
+
+Make sure to securely backup the snap-store-proxy configuration (including the
+proxy.device-auth.secret used for signing/verifying the device sessions). The
+config can be exported with:
+
+```bash
+sudo snap-store-proxy config > proxy-config-backup.txt
+sudo snap-store-proxy config proxy.device-auth.secret > proxy.device-auth.secret.txt
+sudo snap-store-proxy config proxy.auth.secret > proxy.auth.secret.txt
+sudo snap-store-proxy config proxy.key.private > proxy.key.private.txt
+sudo snap-store-proxy config proxy.tls.key > proxy.tls.key.txt
+```
+
+### Client Device Configuration
+
+[Configuring client devices](devices.md) follows the same process as with an
+online Snap Store Proxy.

--- a/en/airgap.md
+++ b/en/airgap.md
@@ -157,16 +157,6 @@ limited to:
 [Configuring client devices](devices.md) follows the same process as with an
 online Snap Store Proxy.
 
-!!! NOTE:
-    Airgapped Snap Store Proxy ignores authentication information sent by client
-    devices currently. However if a client device has already obtained a
-    [serial assertion](https://docs.ubuntu.com/core/en/reference/assertions/serial),
-    but hasn't yet obtained a device session credential from the upstream store,
-    it will not be able to use the air-gapped proxy, as the air-gapped proxy
-    currently is unable to authenticate its client devices offline and the
-    device tries to obtain a session from the store it connects to before
-    talking to that store.
-
 ## Limitations
 
 Air-gapped mode provides only a subset of the core functionality of the regular
@@ -174,4 +164,4 @@ Snap Store Proxy or the official Snap Store. Some of the missing features are:
 
 * Searching for snaps
 
-* Device registration and authorization
+* Device registration

--- a/en/airgap.md
+++ b/en/airgap.md
@@ -46,16 +46,10 @@ Air-gapped Snap Store Proxy operators first have to register their offline proxy
 on a **machine with internet access**:
 
 ```bash
-sudo snap install snap-store-proxy --edge
-
-sudo snap-proxy generate-keys
+sudo snap install snap-store-proxy
 
 sudo snap-proxy config proxy.domain="$<domain-or-ip-of-the-air-gapped-proxy>"
 ```
-
-Follow the [HTTPS setup guide](https.md) to ensure that your offline Snap Store
-Proxy will be registered behind HTTPS scheme, meaning that any client device
-that attempts to use it, will contact it via HTTPS.
 
 On the same machine, register the air-gapped Snap Store Proxy:
 
@@ -64,6 +58,10 @@ On the same machine, register the air-gapped Snap Store Proxy:
 # be asked some survey questions about the intended proxy usage.
 sudo snap-proxy register --offline --channel=edge --arch=amd64
 ```
+
+Add the `--https` option to the above `register` command if client devices are
+expected to use HTTPS to connect to the proxy and follow the [HTTPS
+setup](https.md) before continuing.
 
 The result of the above is a tarball `offline-snap-store.tar.gz` that is then
 moved to the target host machine for the air-gapped Snap Store Proxy.

--- a/en/https.md
+++ b/en/https.md
@@ -5,16 +5,14 @@ table_of_contents: true
 
 # HTTPS
 
-TLS termination is not enabled by default. This means that the traffic between
-your snap devices and the Snap Store Proxy will not be encrypted.
+TLS termination is not enabled by default. This means that the proxy listens
+only on port 80 after installation. If the proxy was [registered](register.md)
+with an `--https` option, the resulting [assertion](devices.md) instructing
+client devices to connect to the proxy instead of the upstream store is pointing
+those devices to use HTTPS to connect to the proxy.
 
-This document explains how to enable TLS termination in the Snap Store Proxy.
-
-!!! NOTE:
-    Follow the instructions below **after** your Snap Store Proxy is
-    [installed](install.md), but **before** it is [registered](register.md) and
-    before any snap devices are [configured](devices.md) to use this Snap Store
-    Proxy.
+This document explains how to enable and configure TLS termination in the Snap
+Store Proxy.
 
 ## Certificate and Key
 
@@ -23,7 +21,8 @@ determine the domain by running:
 
     snap-proxy config proxy.domain
 
-This name will be the subject or one of the alternative names on the certificate.
+This name will be the subject and/or one of the alternative names on the
+certificate.
 
 How to obtain the certificate/key pair is out of scope of this document.
 
@@ -61,7 +60,8 @@ After that, snapd will be able to successfully verify the certificate.
 ## Next step
 
 Once you've confirmed that your Snap Store Proxy is running and accepting HTTPS
-connections, you can [register](register.md) your Snap Store Proxy.
+connections, you can [configure client devices](devices.md) to use your Snap
+Store Proxy.
 
 At any time, you can use:
 

--- a/en/install.md
+++ b/en/install.md
@@ -41,14 +41,12 @@ services, and the `snap-proxy` CLI tool to control the proxy.
 ## Domain configuration
 
 The Snap Store Proxy will require a domain or IP address to be set
-for the configuration and access by other devices.
+for the configuration and access by other devices, e.g.:
 
-    sudo snap-proxy config proxy.domain="<domain>"
+    sudo snap-proxy config proxy.domain="snaps.myorg.internal"
 
 This can be done after the database is created, but is required
 before registration can succeed.
-
-The proxy will listen on all interfaces on port 443 (with a redirect from 80).
 
 ## Database
 
@@ -130,9 +128,7 @@ To reset CA certificates back to defaults, run:
 
 ## Next step
 
-If you want traffic between your devices and your Snap Store Proxy to be
-encrypted, continue to [HTTPS](https.md). Otherwise, proceed with
-[registration](register.md).
+[Register](register.md) your Snap Store Proxy.
 
 ## Running multiple proxies
 

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -3,10 +3,10 @@ navigation:
       location: index.md
     - title: Installation
       location: install.md
-    - title: HTTPS
-      location: https.md
     - title: Proxy registration
       location: register.md
+    - title: HTTPS
+      location: https.md
     - title: Configuring snap devices
       location: devices.md
     - title: Overriding snap revisions

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -23,3 +23,6 @@ navigation:
           location: api-overrides.md
     - title: Air-gapped Snap Store Proxy (beta)
       location: airgap.md
+      children:
+        - title: Device Authenticated Airgap
+          location: airgap-device-auth.md

--- a/en/register.md
+++ b/en/register.md
@@ -33,7 +33,15 @@ To register the proxy, you will need to provide Ubuntu SSO credentials
 for the desired account you wish to link the proxy with, and answer
 some simple questions about your deployment:
 
+    sudo snap-proxy register --https
+
+or:
+
     sudo snap-proxy register
+
+If the `--https` option is omitted, the resulting [assertion](devices.md)
+instructing client devices to use the proxy instead of the upstream store, will
+instruct them to use HTTP to connect to the proxy instead of HTTPS.
 
 You can examine your proxy's registration status with:
 
@@ -50,4 +58,6 @@ with the status command. This will be used in later commands and to
 identify your proxy for support purposes.
 
 ## Next step
-Once your proxy is approved, you will be able to [configure devices](devices.md).
+
+Configure the proxy to [serve HTTPS](https.md) traffic if `--https` registration
+option was used, or proceed to [configure client devices](devices.md).


### PR DESCRIPTION
This makes the setup process less confusing and more explicit up front about the registration results in terms of how the client devices connect to the proxy.

Based on #27.