### PR TITLE
Update metadata footer link to trouble

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ site_title: Snap Store Proxy documentation
 site_logo_url: ../media/snap-store-proxy-logo-32.png
 site_favicon: ../media/snap-store-proxy-logo.ico
 site_footer_links:
-  - location: trouble.html
+  - location: trouble
     title: Troubleshoot issues
   - location: https://bugs.launchpad.net/snapstore
     title: File a bug


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/docs.ubuntu.com/issues/329#issuecomment-1093842621

I believe the real issue is in the documentation-builder project, but it is considered deprecated, I figure I'd create a patch here. If you build and serve the files locally the link will not work, however when this is deployed because of handy-dandy URL rewrites, it will.