### PR TITLE
Removing outdated server info and directing the user to Discourse

### DIFF
--- a/en/install.md
+++ b/en/install.md
@@ -10,9 +10,7 @@ table_of_contents: true
 To run the Snap Store Proxy, you will need:
 
 * A server running Ubuntu 18.04 LTS or newer on AMD64.
-* The ability (e.g. firewall rules) for the server to initiate network
-  connections to https://api.snapcraft.io,
-  https://public.apps.ubuntu.com, and https://login.ubuntu.com.
+* Firewall rules configured to allow traffic to servers mentioned at https://forum.snapcraft.io/t/network-requirements/5147.
 * A domain name for the server.
 * A PostgreSQL instance (see the Database section). 
 


### PR DESCRIPTION
The Discourse page is where we provide updates to server information over time. Instead of maintaining our own lists, it is better to guide the user towards a "canonical" source.

This fixes #39.