### PR TITLE
Extend the docs related to TLS setup and usage of self-signed certs

### DIFF
--- a/en/https.md
+++ b/en/https.md
@@ -8,7 +8,7 @@ table_of_contents: true
 TLS termination is not enabled by default. This means that the proxy listens
 only on port 80 after installation. If the proxy was [registered](register.md)
 with an `--https` option, the resulting [assertion](devices.md) instructing
-client devices to connect to the proxy instead of the upstream store is pointing
+client devices to connect to the proxy instead of the upstream store, is pointing
 those devices to use HTTPS to connect to the proxy.
 
 This document explains how to enable and configure TLS termination in the Snap
@@ -16,46 +16,77 @@ Store Proxy.
 
 ## Certificate and Key
 
-Obtain an x509 key and certificate pair for your Snap Store Proxy domain. You can
-determine the domain by running:
+Obtain an x509 key and certificate pair for your Snap Store Proxy domain (as
+well as any relevant intermediate certificates if applicable). You can determine
+the domain by running:
 
     snap-proxy config proxy.domain
 
-This name will be the subject and/or one of the alternative names on the
-certificate.
+This name will be the subject and should be one of the alternative names on the
+certificate as well.
 
 How to obtain the certificate/key pair is out of scope of this document.
 
 ## Importing the Key/Certificate pair
 
-Running the below command will import the key/certificate pair and re-configure
-your Snap Store Proxy:
+Running the below command will import the key/certificate pair (and any
+intermediate certificates as needed) and re-configure your Snap Store Proxy:
 
-    cat my.cert my.key | sudo snap-proxy import-certificate
+    cat my.cert my.key [intermediate.cert ...]  | sudo snap-proxy import-certificate
+
+For example when configuring a Let's Encrypt issued certificate, you'd want to
+include the key, the certificate and intermediate certificates. Since Let's
+Encrypt provides `fullchain.pem` that includes both the site and intermediate
+certificates, you can use:
+
+    cat fullchain.pem my.key | sudo snap-proxy import-certificate
 
 After this is done, TLS termination will be enabled, and any HTTP traffic to
-your Snap Store Proxy will be redirected to HTTPS.
+your Snap Store Proxy will be redirected to HTTPS. This command can be re-run as
+needed.
 
 ## Self signed certificates
 
-The TLS certificate above may be self signed or issued by a certificate
-authority that is not included in the system certificate store on your snap
-devices. If this is true, then you need to make sure that the certificates in
-question are added to the system certificate store on those devices. On Ubuntu
-devices this might be achieved by placing the certificate in question in a
-specific directory:
+The TLS certificate above may be self signed or ultimately signed by a self
+signed root CA that is not included in the system certificate store on your
+client snap devices or the snap-store-proxy host itself. If this is true, then
+you need to make sure that the self signed certificates in question are added
+to:
 
-    sudo cp selfsigned.crt /usr/local/share/ca-certificates/
+* the system certificate store on the snap-store-proxy host,
 
-then running:
+* as well as its client devices.
+
+On classic Ubuntu machines this might be achieved by placing the certificate in
+question in a specific directory:
+
+    sudo cp my-selfsigned-ca.crt /usr/local/share/ca-certificates/
+
+(make sure that the certificate file extension is `.crt`) then running:
 
     sudo update-ca-certificates
 
-and finally, `snapd` has to be restarted.
+If this is being done on the snap-store-proxy host, the snap-store-proxy has to be restarted:
+
+    sudo snap restart snap-store-proxy
+
+After that, snap-store-proxy will be able to verify its status correctly.
+
+For client machines, snapd has to be restarted:
 
     sudo systemctl restart snapd
 
-After that, snapd will be able to successfully verify the certificate.
+After that, snapd on the client device will be able to successfully verify the
+snap-store-proxy certificate.
+
+A more robust method of ensuring that client devices can talk to the
+snap-store-proxy using a self signed certificate or one issued by a self signed
+root is to configure the certificate in question using snapd itself:
+
+    sudo snap set system store-certs.cert1="$(cat /path/to/my-cert-or-ca-cert.crt)"
+
+The above method works both on classic systems as well as Ubuntu Core.
+
 
 ## Next step
 

--- a/en/install.md
+++ b/en/install.md
@@ -107,18 +107,22 @@ Snap Store Proxy also uses the `https_proxy` environment variable if it's set.
 ## CA certificates
 
 For verifying outgoing HTTPS communication, Snap Store Proxy bundles a set of
-root [CAs](https://en.wikipedia.org/wiki/Certificate_authority) from
-[The Certifi Trust Database](https://certifi.io/).
+root [CAs](https://en.wikipedia.org/wiki/Certificate_authority) from its base
+Ubuntu based snap.
 
-You can override this default behavior and configure your Snap Store Proxy to
-only trust a specific list of CAs:
+On Ubuntu, the system trust store can be modified using `update-ca-certificates`
+as needed and snap-store-proxy will honour these changes by default (it might
+require a restart `sudo snap restart snap-store-proxy`).
+
+You can also override this default behavior and configure your Snap Store Proxy
+to _only_ trust a specific list of CAs:
 
     cat your-ca.crt another-ca.crt | sudo snap-proxy use-ca-certs
 
-This can be useful in cases when you want your Snap Store Proxy to trust your
-internal CA for example.
+This can be useful in cases when you want your Snap Store Proxy to only trust
+your internal CA for example.
 
-To reset CA certificates back to defaults, run:
+To reset the CA certificates back to the system defaults, run:
 
     sudo snap-proxy remove-ca-certs
 


### PR DESCRIPTION
The changes are most compatible with improvements and fixes coming in snap-store-proxy 2.23.