### PR TITLE
Bump the minimum version of Ubuntu required to focal

### DIFF
--- a/en/install.md
+++ b/en/install.md
@@ -9,7 +9,7 @@ table_of_contents: true
 
 To run the Snap Store Proxy, you will need:
 
-* A server running Ubuntu 18.04 LTS or newer on AMD64.
+* A server running Ubuntu 20.04 LTS or newer on AMD64.
 * Firewall rules configured to allow traffic to servers mentioned at https://forum.snapcraft.io/t/network-requirements/5147.
 * A domain name for the server.
 * A PostgreSQL instance (see the Database section). 


### PR DESCRIPTION
20.04 is not new anymore and upcoming move to core22 base has issues with 18.04's openssl.