### PR TITLE
Refactor docs to conform to Diátaxis home page structure

### DIFF
--- a/en/explanation.md
+++ b/en/explanation.md
@@ -1,0 +1,25 @@
+---
+title: Snap Store Proxy Explanation guides
+---
+
+# Snap Store Proxy Explanation guides
+
+Our explanatory and conceptual guides are written to provide a better understanding of
+how the Snap Store Proxy works and how it can be used and configured. They enable you
+to expand your knowledge and become better at using the Proxy.
+
+| **Explanation guides** | Why it does what it does |
+|------------------------|--------------------------|
+|                        |                          |
+
+For a simpler place to start with the Proxy, our *Tutorials* section contains
+step-by-step tutorials to outline what the Proxy is capable of while helping
+you achieve specific aims, such as configuring revision overrides
+
+If you have a specific goal, but are already familiar with the Proxy, our *How-to*
+guides have more in-depth detail than our tutorials and can be applied to a broader set
+of applications. They’ll help you achieve an end-result but may require you to understand
+and adapt the steps to fit your specific requirements.
+
+Take a look at our *Reference* section for technical details (such as the Overrides API
+specs and authentication mechanism), and other supplementary reference materials.

--- a/en/explanation.md
+++ b/en/explanation.md
@@ -14,7 +14,7 @@ to expand your knowledge and become better at using the Proxy.
 
 For a simpler place to start with the Proxy, our *Tutorials* section contains
 step-by-step tutorials to outline what the Proxy is capable of while helping
-you achieve specific aims, such as configuring revision overrides
+you achieve specific aims.
 
 If you have a specific goal, but are already familiar with the Proxy, our *How-to*
 guides have more in-depth detail than our tutorials and can be applied to a broader set

--- a/en/feature-list.md
+++ b/en/feature-list.md
@@ -1,0 +1,40 @@
+---
+title: Feature list
+---
+
+# Feature list
+
+* Network control
+
+    * Provides a means to access the Snap Store for devices with restricted
+      network access
+
+    * Snap Store Proxy can communicate with the Snap Store directly or through
+      an HTTPS forward proxy
+
+* Caching of the downloaded snaps
+
+* [Overriding revisions](overrides.md) of specific snaps for all connected
+  devices
+
+* Management options
+
+    * `snap-proxy` CLI interface included with the
+      [Snap Store Proxy](https://snapcraft.io/snap-store-proxy) snap
+
+    * Remote management using the
+      [Snap Store Proxy Client](https://snapcraft.io/snap-store-proxy-client)
+      or a [RESTful API](api-overrides.md).
+
+* [Offline mode](airgap.md).
+
+!!! NOTE:
+    Unless it is deliberately set up as [offline](airgap.md), a Snap Store Proxy needs to be online
+    and connected to the general [Snap Store](https://snapcraft.io/store). This
+    is a requirement, even though Snap Store Proxy caches downloaded snap files,
+    which substantially reduces internet traffic. There's currently no generally
+    available offline mode for the Snap Store Proxy itself. See
+    [Network Connectivity](install.md#network-connectivity) for the
+    `snap-proxy check-connections` command and the up-to-date
+    [Network requirements for Snappy](https://forum.snapcraft.io/t/network-requirements-for-snappy/5147)
+    post for a list of domains Snap Store Proxy needs access to.

--- a/en/how-to.md
+++ b/en/how-to.md
@@ -1,0 +1,24 @@
+---
+title: Snap Store Proxy How-to guides
+---
+
+# Snap Store Proxy How-to guides
+
+If you have a specific goal, but are already familiar with the Snap Store Proxy,
+our *How-to* guides have more in-depth detail than our tutorials and can be applied to
+a broader set of applications. They’ll help you achieve an end result but may require
+you to understand and adapt the steps to fit your specific requirements.
+
+| **How-to guides**             | Get stuff done                                              |
+|-------------------------------|-------------------------------------------------------------|
+| [Troubleshooting](trouble.md) | Check Proxy configuration status and diagnose common issues |
+
+Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
+what the Proxy is capable of while helping you achieve specific aims,
+such as configuring revision overrides.
+
+Take a look at our *Reference* section for technical details (such as the Overrides API
+specs and authentication mechanism), and other supplementary reference materials.
+
+Finally, for a better understanding of how the Snap Store Proxy works, our *Explanation*
+section enables you to expand your knowledge.

--- a/en/how-to.md
+++ b/en/how-to.md
@@ -9,13 +9,19 @@ our *How-to* guides have more in-depth detail than our tutorials and can be appl
 a broader set of applications. They’ll help you achieve an end result but may require
 you to understand and adapt the steps to fit your specific requirements.
 
-| **How-to guides**             | Get stuff done                                              |
-|-------------------------------|-------------------------------------------------------------|
-| [Troubleshooting](trouble.md) | Check Proxy configuration status and diagnose common issues |
+| **How-to guides**                         | Get stuff done                                                        |
+|-------------------------------------------|-----------------------------------------------------------------------|
+| [Installation](install.md)                | Install and set up the Snap Store Proxy                               |
+| [Proxy registration](register.md)         | Register the Proxy with the online Snap Store                         |
+| [TLS configuration](https.md)             | Configure TLS termination in the Proxy                                |
+| [Configuring snap devices](devices.md)    | Point your devices to the Proxy instead of the online Snap Store      |
+| [Overriding snap revisions](overrides.md) | Control the specific revision of a snap in a channel for your devices |
+| [Offline store](airgap.md)                | Deploy the Proxy in an air-gapped environment                         |
+| [Model service](on-prem-model-service.md) | Configure an air-gapped Proxy for signing device serial requests      |
+| [Troubleshooting](trouble.md)             | Check Proxy configuration status and diagnose common issues           |
 
 Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
-what the Proxy is capable of while helping you achieve specific aims,
-such as configuring revision overrides.
+what the Proxy is capable of while helping you achieve specific aims.
 
 Take a look at our *Reference* section for technical details (such as the Overrides API
 specs and authentication mechanism), and other supplementary reference materials.

--- a/en/index.md
+++ b/en/index.md
@@ -4,50 +4,42 @@ title: Introduction
 
 # Snap Store Proxy documentation
 
-The Snap Store Proxy provides an on-premise edge proxy to the general
-[Snap Store](https://snapcraft.io/store) for your devices. Devices are
-registered with the proxy, and all communication with the Store will flow
-through the proxy.
+The **Snap Store Proxy** provides an on-premise edge proxy to the general
+[Snap Store](https://snapcraft.io/store) for your devices.
 
-!!! NOTE:
-    Unless it is deliberately set up as [offline](airgap.md), a Snap Store Proxy needs to be online
-    and connected to the general [Snap Store](https://snapcraft.io/store). This
-    is a requirement, even though Snap Store Proxy caches downloaded snap files,
-    which substantially reduces internet traffic. There's currently no generally
-    available offline mode for the Snap Store Proxy itself. See
-    [Network Connectivity](install.md#network-connectivity) for the
-    `snap-proxy check-connections` command and the up-to-date
-    [Network requirements for Snappy](https://forum.snapcraft.io/t/network-requirements-for-snappy/5147)
-    post for a list of domains Snap Store Proxy needs access to.
+Devices are registered with the Proxy, and all communication with the Snap Store will
+**flow through the Proxy**, thereby enabling network-restricted devices to access snaps.
+Upstream snap **revisions can be overriden** on the Proxy, allowing fine-grained revision
+control for your devices. The Proxy furthermore supports air-gapped deployments when
+configured in **offline mode**.
 
-## Feature list
+The Proxy is an excellent fit for organisations looking for **more control
+over updates** to their snaps, or for enterprises that have held back from adopting
+snaps until now because of the challenges of operating within a **restricted
+network**.
 
-* Network control
+With the Snap Store Proxy, snaps are as easy-to-use as ever, and administrators
+have much greater control over exactly what revisions are installed on each
+connected system.
 
-    * Provides a means to access the Snap Store for devices with restricted
-      network access
+---
 
-    * Snap Store Proxy can communicate with the Snap Store directly or through
-      an HTTPS forward proxy
+## In this documentation
 
-* Caching of the downloaded snaps
+|                                                                                                                 |                                                                                               |
+|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| [Tutorials](tutorial.md)</br> Get started - a hands-on introduction to the Snap Store Proxy for new users </br> | [How-to guides](how-to.md) </br> Step-by-step guides covering key operations and common tasks |
+| [Reference](reference.md) </br> Technical information - specifications, APIs, architecture                      | [Explanation](explanation.md) </br> Concepts - discussion and clarification of key topics     |
 
-* [Overriding revisions](overrides.md) of specific snaps for all connected
-  devices
+---
 
-* Management options
+## Project and community
 
-    * `snap-proxy` CLI interface included with the
-      [Snap Store Proxy](https://snapcraft.io/snap-store-proxy) snap
+The Snap Store Proxy is a member of the Snap Store family. It's a project that welcomes suggestions, fixes and constructive feedback.
 
-    * Remote management using the
-      [Snap Store Proxy Client](https://snapcraft.io/snap-store-proxy-client)
-      or a [RESTful API](api-overrides.md).
+* [Get the Snap Store Proxy as a snap](https://snapcraft.io/snap-store-proxy)
+* [Join the Discourse forum](https://forum.snapcraft.io/c/store/16)
+* [File a bug](https://bugs.launchpad.net/snapstore-server)
+* [Get support](https://ubuntu.com/support/community-support)
 
-* [Offline mode](airgap.md).
-
-## Whitepaper
-
-Learn more about how the Snap Store Proxy overcomes challenges presented by
-restricted networks and management policies from this
-[whitepaper on Enterprise Snap Management](https://ubuntu.com/engage/enterprise-snap-management).
+Thinking about deploying the Snap Store Proxy in your enterprise? [Get in touch!](https://ubuntu.com/core/services#get-in-touch)

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -3,6 +3,8 @@ navigation:
       location: index.md
     - title: Tutorial
       location: tutorial.md
+    - title: How-to guides
+      location: how-to.md
       children:
         - title: Installation
           location: install.md
@@ -18,9 +20,6 @@ navigation:
           location: airgap.md
         - title: On-prem model service
           location: on-prem-model-service.md
-    - title: How-to guides
-      location: how-to.md
-      children:
         - title: Troubleshooting
           location: trouble.md
     - title: Reference

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -1,26 +1,38 @@
 navigation:
-    - title: Introduction
+    - title: Home
       location: index.md
-    - title: Installation
-      location: install.md
-    - title: Proxy registration
-      location: register.md
-    - title: HTTPS
-      location: https.md
-    - title: Configuring snap devices
-      location: devices.md
-    - title: Overriding snap revisions
-      location: overrides.md
-    - title: Offline store
-      location: airgap.md
+    - title: Tutorial
+      location: tutorial.md
       children:
+        - title: Installation
+          location: install.md
+        - title: Proxy registration
+          location: register.md
+        - title: HTTPS
+          location: https.md
+        - title: Configuring snap devices
+          location: devices.md
+        - title: Overriding snap revisions
+          location: overrides.md
+        - title: Offline store
+          location: airgap.md
         - title: On-prem model service
           location: on-prem-model-service.md
-    - title: Troubleshooting
-      location: trouble.md
-    - title: API documentation
+    - title: How-to guides
+      location: how-to.md
       children:
-        - title: API authentication
-          location: api-authentication.md
+        - title: Troubleshooting
+          location: trouble.md
+    - title: Reference
+      location: reference.md
+      children:
         - title: Overrides API
           location: api-overrides.md
+        - title: API authentication
+          location: api-authentication.md
+        - title: Feature list
+          location: feature-list.md
+        - title: Product whitepaper
+          location: whitepaper.md
+    - title: Explanation
+      location: explanation.md

--- a/en/on-prem-model-service.md
+++ b/en/on-prem-model-service.md
@@ -120,6 +120,11 @@ test-key  PPkB6XcYjkxzA9c6dXsaM0sg9r_d5DZ2kDYvWPTeuSXofXGzMDBt7DoD_Xiw3see
 
 The `BRAND_ACCOUNT_ID` environment variable only needs to be set once; it will be stored and automatically used subsequently.
 
+!!! Neutral "Note":
+    If a 4096-bit RSA key takes more than 15 seconds to generate on your hardware
+    (e.g. Nitrokeys), then you would first have to extend the Proxy's internal service timeout:
+    `sudo snap-store-proxy config internal.publishergw.snapmodels.read-timeout={timeout-in-seconds}`
+
 The key needs to be registered with the online Snap Store before it can sign serials:
 
 ```bash

--- a/en/reference.md
+++ b/en/reference.md
@@ -1,0 +1,27 @@
+---
+title: Snap Store Proxy Reference
+---
+
+# Snap Store Proxy Reference
+
+Our *Reference* section contains technical details (such as the Overrides API specs and
+authentication mechanism), and other supplementary reference materials.
+
+| **Reference**                               | How the Proxy works                                                      |
+|---------------------------------------------|--------------------------------------------------------------------------|
+| [Overrides API](api-overrides.md)           | API specs for the Overrides API                                          |
+| [API authentication](api-authentication.md) | API authentication for Proxy admins when using the Overrides API         |
+| [Feature list](feature-list.md)             | A summarized list of features of the Proxy                               |
+| [Product whitepaper](whitepaper.md)         | Whitepaper on managing snaps in an enterprise environment with the Proxy |
+
+Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
+what the Proxy is capable of while helping you achieve specific aims,
+such as configuring revision overrides.
+
+If you have a specific goal, but are already familiar with the Snap Store Proxy,
+our *How-to* guides have more in-depth detail than our tutorials and can be applied to
+a broader set of applications. They’ll help you achieve an end result but may require
+you to understand and adapt the steps to fit your specific requirements.
+
+Finally, for a better understanding of how the Snap Store Proxy works, our *Explanation*
+section enables you to expand your knowledge.

--- a/en/reference.md
+++ b/en/reference.md
@@ -15,8 +15,7 @@ authentication mechanism), and other supplementary reference materials.
 | [Product whitepaper](whitepaper.md)         | Whitepaper on managing snaps in an enterprise environment with the Proxy |
 
 Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
-what the Proxy is capable of while helping you achieve specific aims,
-such as configuring revision overrides.
+what the Proxy is capable of while helping you achieve specific aims.
 
 If you have a specific goal, but are already familiar with the Snap Store Proxy,
 our *How-to* guides have more in-depth detail than our tutorials and can be applied to

--- a/en/tutorial.md
+++ b/en/tutorial.md
@@ -1,0 +1,32 @@
+---
+title: Snap Store Proxy Tutorials
+---
+
+# Snap Store Proxy Tutorials
+
+This section of our documentation contains step-by-step tutorials to help outline what
+the Snap Store Proxy is capable of while helping you achieve specific aims.
+
+We hope our tutorials make as few assumptions as possible and are broadly accessible
+to anyone with an interest in the Snap Store Proxy. They should also be a good place
+to start learning about the Proxy, how it works and what it’s capable of.
+
+| **Tutorials**                             | Step-by-step walkthroughs                                             |
+|-------------------------------------------|-----------------------------------------------------------------------|
+| [Installation](install.md)                | Install and set up the Snap Store Proxy                               |
+| [Proxy registration](register.md)         | Register the Proxy with the online Snap Store                         |
+| [TLS configuration](https.md)             | Configure TLS termination in the Proxy                                |
+| [Configuring snap devices](devices.md)    | Point your devices to the Proxy instead of the online Snap Store      |
+| [Overriding snap revisions](overrides.md) | Control the specific revision of a snap in a channel for your devices |
+| [Offline store](airgap.md)                | Deploy the Proxy in an air-gapped environment                         |
+| [Model service](on-prem-model-service.md) | Configure an air-gapped Proxy for signing device serial requests      |
+
+If you have a specific goal, but are already familiar with the Snap Store Proxy,
+take a look at our *How-to* guides. These have more in-depth detail and can be applied
+to a broader set of applications.
+
+Take a look at our *Reference* section for technical details (such as the Overrides API
+specs and authentication mechanism), and other supplementary reference materials.
+
+Finally, for a better understanding of how the Snap Store Proxy works, our *Explanation*
+section enables you to expand your knowledge.

--- a/en/tutorial.md
+++ b/en/tutorial.md
@@ -11,15 +11,9 @@ We hope our tutorials make as few assumptions as possible and are broadly access
 to anyone with an interest in the Snap Store Proxy. They should also be a good place
 to start learning about the Proxy, how it works and what it’s capable of.
 
-| **Tutorials**                             | Step-by-step walkthroughs                                             |
-|-------------------------------------------|-----------------------------------------------------------------------|
-| [Installation](install.md)                | Install and set up the Snap Store Proxy                               |
-| [Proxy registration](register.md)         | Register the Proxy with the online Snap Store                         |
-| [TLS configuration](https.md)             | Configure TLS termination in the Proxy                                |
-| [Configuring snap devices](devices.md)    | Point your devices to the Proxy instead of the online Snap Store      |
-| [Overriding snap revisions](overrides.md) | Control the specific revision of a snap in a channel for your devices |
-| [Offline store](airgap.md)                | Deploy the Proxy in an air-gapped environment                         |
-| [Model service](on-prem-model-service.md) | Configure an air-gapped Proxy for signing device serial requests      |
+| **Tutorials** | Step-by-step walkthroughs |
+|---------------|---------------------------|
+|               |                           |
 
 If you have a specific goal, but are already familiar with the Snap Store Proxy,
 take a look at our *How-to* guides. These have more in-depth detail and can be applied

--- a/en/whitepaper.md
+++ b/en/whitepaper.md
@@ -1,0 +1,9 @@
+---
+title: Whitepaper on Enterprise Snap Management
+---
+
+# Whitepaper
+
+Learn more about how the Snap Store Proxy overcomes challenges presented by
+restricted networks and management policies from this
+[whitepaper on Enterprise Snap Management](https://ubuntu.com/engage/enterprise-snap-management).


### PR DESCRIPTION
We are required in our roadmap to update the home pages of our Store 
documentations to adhere to the standard model as defined in the Diátaxis framework. 
This commit thus creates the "Tutorial", "How-to", "Explanation" 
and "Reference" buckets, and redistribute existing content into them. No 
existing content has been deleted or rewritten, only reshuffled.

Adding new content to the docs to fill in requirements defined in Diátaxis 
that are currently missing is out of the scope of this commit. The "Explanation" 
bucket is empty for now because salient explanation points are currently 
subsumed into the step-by-step tutorials.

Solves: https://warthogs.atlassian.net/browse/SN-2192
What is Diátaxis: https://diataxis.fr

Standard model template: https://docs.google.com/document/d/1Zw-UoQzHMSQjATLXjjvd9GKu5qU2mHmqxtKck8nGkbU/edit
Ubuntu Core docs was used as a reference and some parts are cookie cutted from there: https://ubuntu.com/core/docs