### PR TITLE
updating references to tutorials and examples, and snap status examples

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -23,14 +23,8 @@ you to understand and adapt the steps to fit your specific requirements.
 | [Troubleshooting](how-to/trouble.md)             | Check Proxy configuration status and diagnose common issues           |
 | [Migrate](how-to/migrate.md)                     | How to migrate from the Snap Store Proxy snap to the Enterprise Store snap             |
 
-Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
-what the Proxy is capable of while helping you achieve specific aims.
-
 Take a look at our *Reference* section for technical details (such as the Overrides API
 specs and authentication mechanism), and other supplementary reference materials.
-
-Finally, for a better understanding of how the Enterprise Store works, our *Explanation*
-section enables you to expand your knowledge.
 
 ```{eval-rst}
 .. toctree::

--- a/docs/how-to/register.md
+++ b/docs/how-to/register.md
@@ -18,7 +18,7 @@ or:
     sudo enterprise-store register
 
 If the `--https` option is omitted, the resulting [assertion](devices.md)
-instructing client devices to use the proxy instead of the upstream store, will
+instructing client devices to use the proxy instead of the upstream store will
 instruct them to use HTTP to connect to the proxy instead of HTTPS.
 
 You can examine your proxy's registration status with:
@@ -26,7 +26,33 @@ You can examine your proxy's registration status with:
     enterprise-store status
 
 This will show the registration status of your proxy, as well as local
-status information of this server.
+status information of this store's host.
+
+Example:
+```zsh
+$ enterprise-store status
+
+Store URL: http://proxy.example.com
+Store DB: ok
+Store is in air-gapped mode
+Store ID: id
+Internal Service Status:
+  memcached: running
+  nginx: not running: 500 Server Error: Internal Server Error for url: http://127.0.0.1/_status/check
+  packagereview: running
+  packagereview-worker: running
+  publishergw: running
+  snapassert: running
+  snapauth: running
+  snapdevicegw: running
+  snapdevicegw-local: running
+  snapident: running
+  snapmodels: running
+  snapproxy: running
+  snaprevs: running
+  snapstorage: running
+  storeadmingw: running
+```
 
 At this point, your proxy will be assigned a Store ID, which can be retrieved
 with the status command. This will be used in later commands and to

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -14,16 +14,10 @@ authentication mechanism), and other supplementary reference materials.
 | [Feature list](reference/feature-list.md)             | A summarised list of features of the Proxy                               |
 | [Cryptography](reference/cryptography.md)             | An Outline of the usage of cryptographic technology                      |
 
-Alternatively, our *Tutorials* section contain step-by-step tutorials to help outline
-what the Proxy is capable of while helping you achieve specific aims.
-
 If you have a specific goal, but are already familiar with the Enterprise Store,
 our *How-to* guides have more in-depth detail than our tutorials and can be applied to
 a broader set of applications. They’ll help you achieve an end result but may require
 you to understand and adapt the steps to fit your specific requirements.
-
-Finally, for a better understanding of how the Enterprise Store works, our *Explanation*
-section enables you to expand your knowledge.
 
 ```{eval-rst}
 .. toctree::


### PR DESCRIPTION
minor cleanup of enterpise store docs:
- removing references to tutorials and examples
- grammer cleanup
- example of enterprise-store status output
SN-4582