### PR TITLE
fix(tutorial/air-gapped-deployment): fix typo

### DIFF
--- a/docs/tutorial/air-gapped-deployment.md
+++ b/docs/tutorial/air-gapped-deployment.md
@@ -277,7 +277,7 @@ curl: (7) Failed to connect to api.snapcraft.io port 80 after 4103 ms: Network i
 
 ## Install your offline store
 
-In **test-offine-store**, install PostgreSQL and its dependency `core24`:
+In **test-offline-store**, install PostgreSQL and its dependency `core24`:
 
 ```{terminal}
 :user: root


### PR DESCRIPTION
This PR corrects "test-offine-store" to "test-offline-store".